### PR TITLE
Fix bounds

### DIFF
--- a/hexpat-lens.cabal
+++ b/hexpat-lens.cabal
@@ -9,6 +9,7 @@ copyright:           (c) 2013, Joseph Abrahamson
 category:            XML
 build-type:          Simple
 cabal-version:       >=1.10
+homepage:            https://github.com/tel/hexpat-lens
 
 library
   exposed-modules:

--- a/hexpat-lens.cabal
+++ b/hexpat-lens.cabal
@@ -18,8 +18,8 @@ library
     Text.XML.Expat.Lens.Parse
     Text.XML.Expat.Lens.Unqualified
   build-depends:       
-      base            >= 4.6      && < 4.8
-    , deepseq         >= 1.3      && < 1.4
+      base            >= 4.6      && < 4.9
+    , deepseq         >= 1.3      && < 1.5
     , bytestring      >= 0.10.0.2 && < 0.11
     , hexpat          >= 0.20     && < 0.21
     , lens            >= 4.0.7    && < 5.0

--- a/hexpat-lens.cabal
+++ b/hexpat-lens.cabal
@@ -1,5 +1,5 @@
 name:                hexpat-lens
-version:             0.1.3
+version:             0.1.4
 synopsis:            Lenses for Hexpat.
 license:             MIT
 license-file:        LICENSE


### PR DESCRIPTION
This bumps a few upper bounds on dependencies to make the library build with GHC 7.10. I have tested it on my computer and it works. Additionally, I've added a link to this github repo as the homepage in the cabal file.