### PR TITLE
Bump upper bound for base dependency

### DIFF
--- a/hexpat-lens.cabal
+++ b/hexpat-lens.cabal
@@ -20,7 +20,7 @@ library
     Text.XML.Expat.Lens.Parse
     Text.XML.Expat.Lens.Unqualified
   build-depends:       
-      base            >= 4.6      && < 4.9
+      base            >= 4.6      && < 4.10
     , deepseq         >= 1.3      && < 1.5
     , bytestring      >= 0.10.0.2 && < 0.11
     , hexpat          >= 0.20     && < 0.21


### PR DESCRIPTION
So that it works with GHC 8.0.2